### PR TITLE
feat: use typescript compiler to transform scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ Dead simple statyk site generator
 
 > for the impatient:
 > Clone repo -> run `yarn` -> run `yarn dev --watch`
+
+TODOS
+
+- Content folders support
+- JS API for creating pages
+- Compile scripts with AST
+- Support extrating scripts to external js script
+- Support for <style\> tag

--- a/examples/simple/pages/test.md
+++ b/examples/simple/pages/test.md
@@ -2,12 +2,5 @@
 
   ## Hello world
 
-  {{
-    map(["anuraghazra", "saurabhdaware", "HarshKapadia2"], 
-    (username) => {
-      return `
-        <include src="partials/avatar.html" username="${username}" />
-      `
-    })
-  }}
+  <include src="partials/counter.html" count="10" />
 </include>

--- a/examples/simple/partials/counter.html
+++ b/examples/simple/partials/counter.html
@@ -1,0 +1,23 @@
+<span class="flex gap-2 items-center mt-2">
+  <button hashid="dec-btn" class="btn">-</button>
+  <span hashid="count">{{props.count}}</span>
+  <button hashid="inc-btn" class="btn">+</button>
+</span>
+
+<script>
+  let count = parseInt(props.count || 0);
+  const step = parseInt(props.step || 1);
+  console.log(props, count, step);
+  const countElm = getElementByHashId("count");
+  const incEl = getElementByHashId("inc-btn");
+  const decEl = getElementByHashId("dec-btn");
+
+  incEl.addEventListener("click", () => {
+    count += step;
+    countElm.innerHTML = count;
+  });
+  decEl.addEventListener("click", () => {
+    count -= step;
+    countElm.innerHTML = count;
+  });
+</script>

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "serve-static": "^1.14.2",
     "shortid": "^2.2.16",
     "source-map-support": "^0.5.21",
+    "typescript": "^4.5.4",
     "vm2": "^3.9.5"
   }
 }

--- a/src/core/instanceComponentScript.js
+++ b/src/core/instanceComponentScript.js
@@ -35,34 +35,33 @@ function transformGetByHashId(sid, allIdNames) {
     /** @type {ts.Visitor} */
     const visit = (node) => {
       if (ts.isCallExpression(node)) {
-        if (node.expression.escapedText === HASH_ID_FUNC) {
-          const arg = node.arguments[0];
-          if (!arg) {
-            throw new Error(`${HASH_ID_FUNC} expects 1 argument but got zero`);
-          }
-          if (!ts.isStringLiteral(arg)) {
-            throw new TypeError(`${HASH_ID_FUNC} only accepts string`);
-          }
-          const idName = arg.text;
-          processHashElements(idName, sid, allIdNames);
+        if (node.expression.escapedText !== HASH_ID_FUNC) return node;
 
-          return ts.factory.updateCallExpression(
-            node,
-            ts.factory.createPropertyAccessExpression(
-              ts.factory.createIdentifier("document"),
-              "getElementById"
-            ),
-            [],
-            [
-              ts.factory.createBinaryExpression(
-                ts.factory.createIdentifier("__id"),
-                ts.SyntaxKind.PlusToken,
-                ts.factory.createStringLiteral(`-${idName}`)
-              ),
-            ]
-          );
+        const arg = node.arguments[0];
+        if (!arg) {
+          throw new Error(`${HASH_ID_FUNC} expects 1 argument but got zero`);
         }
-        return node;
+        if (!ts.isStringLiteral(arg)) {
+          throw new TypeError(`${HASH_ID_FUNC} only accepts string`);
+        }
+        const idName = arg.text;
+        processHashElements(idName, sid, allIdNames);
+
+        return ts.factory.updateCallExpression(
+          node,
+          ts.factory.createPropertyAccessExpression(
+            ts.factory.createIdentifier("document"),
+            "getElementById"
+          ),
+          [],
+          [
+            ts.factory.createBinaryExpression(
+              ts.factory.createIdentifier("__id"),
+              ts.SyntaxKind.PlusToken,
+              ts.factory.createStringLiteral(`-${idName}`)
+            ),
+          ]
+        );
       }
       return ts.visitEachChild(node, (child) => visit(child), context);
     };

--- a/src/core/instanceComponentScript.js
+++ b/src/core/instanceComponentScript.js
@@ -7,6 +7,8 @@ import ts from "typescript";
 import { stringifyObject } from "./runExpression";
 import { coreRuntime } from "./compile";
 
+const HASH_ID_FUNC = "getElementByHashId";
+
 /**
  * @template {ts.Node} T
  * @param {string} sid
@@ -18,12 +20,13 @@ function transformGetByHashId(sid, allIdNames) {
     /** @type {ts.Visitor} */
     const visit = (node) => {
       if (ts.isCallExpression(node)) {
-        if (node.expression.escapedText === "getElementByHashId") {
+        if (node.expression.escapedText === HASH_ID_FUNC) {
           const arg = node.arguments[0];
           if (!arg) {
-            throw new Error(
-              "getElementByHashId expects 1 argument but got zero"
-            );
+            throw new Error(`${HASH_ID_FUNC} expects 1 argument but got zero`);
+          }
+          if (!ts.isStringLiteral(arg)) {
+            throw new TypeError(`${HASH_ID_FUNC} only accepts `);
           }
           const idName = arg.text;
           const element = allIdNames[idName];
@@ -49,9 +52,8 @@ function transformGetByHashId(sid, allIdNames) {
               ),
             ]
           );
-        } else {
-          return node;
         }
+        return node;
       }
       return ts.visitEachChild(node, (child) => visit(child), context);
     };

--- a/src/core/instanceComponentScript.js
+++ b/src/core/instanceComponentScript.js
@@ -10,6 +10,21 @@ import { coreRuntime } from "./compile";
 const HASH_ID_FUNC = "getElementByHashId";
 
 /**
+ * @param {string} idName
+ * @param {string} sid
+ * @param {HTMLScriptElement[]} allIdNames
+ */
+function processHashElements(idName, sid, allIdNames) {
+  const element = allIdNames[idName];
+  const newId = `${sid}-${idName}`;
+  if (!element) {
+    throw new Error(`Cannot find element with hashid: ${idName}`);
+  }
+  element.setAttribute("id", newId);
+  element.removeAttribute("hashid");
+}
+
+/**
  * @template {ts.Node} T
  * @param {string} sid
  * @param {HTMLScriptElement[]} allIdNames
@@ -26,16 +41,10 @@ function transformGetByHashId(sid, allIdNames) {
             throw new Error(`${HASH_ID_FUNC} expects 1 argument but got zero`);
           }
           if (!ts.isStringLiteral(arg)) {
-            throw new TypeError(`${HASH_ID_FUNC} only accepts `);
+            throw new TypeError(`${HASH_ID_FUNC} only accepts string`);
           }
           const idName = arg.text;
-          const element = allIdNames[idName];
-          const newId = `${sid}-${idName}`;
-          if (!element) {
-            throw new Error(`Cannot find element with hashid: ${idName}`);
-          }
-          element.setAttribute("id", newId);
-          element.removeAttribute("hashid");
+          processHashElements(idName, sid, allIdNames);
 
           return ts.factory.updateCallExpression(
             node,

--- a/yarn.lock
+++ b/yarn.lock
@@ -714,6 +714,11 @@ toidentifier@1.0.1:
   resolved "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+typescript@^4.5.4:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
+  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz"


### PR DESCRIPTION
Instead of using regexes to convert `getElementByHashId` to `document.getElementById` use TypeScript compiler. 

Reasons to choose TS compiler instead of acorn or babel: 
- I might be adding ts support inside <script /> tags so it's better to transpile with ts itself
- Enables us to provide diagnostics based on type information in the template